### PR TITLE
Timestamped IPython prompt

### DIFF
--- a/startup/01-prompt.py
+++ b/startup/01-prompt.py
@@ -1,0 +1,14 @@
+import datetime
+from IPython.terminal.prompts import Prompts, Token
+
+
+class MyPrompt(Prompts):
+    def in_prompt_tokens(self, cli=None):
+        return [(Token.CursorLine, f'{datetime.datetime.isoformat(datetime.datetime.now())}'),
+                (Token.Prompt, ' ['),
+                (Token.PromptNum, str(self.shell.execution_count)),
+                (Token.Prompt, '] ' + u"\u25B6" + ' ')]
+
+
+ip = get_ipython()
+ip.prompts = MyPrompt(ip)


### PR DESCRIPTION
Based on the idea from https://github.com/NSLS-II-BMM/profile_collection/blob/master/startup/94-prompt.py.

Sample output:
```
18:09 $ ipython
Python 3.7.6 (default, Jan  8 2020, 13:42:34)
Type 'copyright', 'credits' or 'license' for more information
IPython 7.12.0 -- An enhanced Interactive Python. Type '?' for help.

2020-02-26T18:09:14.583191 [1] ▶

2020-02-26T18:09:15.516255 [1] ▶

2020-02-26T18:09:15.671965 [1] ▶ import numpy as np

2020-02-26T18:09:21.961324 [2] ▶ print('My new prompt!')
My new prompt!

2020-02-26T18:09:32.802153 [3] ▶
```