### PR TITLE
Add a check for the 'det_mode'

### DIFF
--- a/startup/30-geometry.py
+++ b/startup/30-geometry.py
@@ -16,6 +16,10 @@ import bluesky.plan_stubs as bps
 from ophyd.positioner import SoftPositioner
 
 
+class UserError(Exception):
+    ...
+
+
 class EpicsMotorWithLimits(EpicsMotor):
     low_limit = Cpt(EpicsSignal, ".LLM")
     high_limit = Cpt(EpicsSignal, ".HLM")
@@ -270,6 +274,11 @@ class Geometry(PseudoPositioner):
             2: 'det_2',
             3: 'det_3',
         }
+
+        if det_mode not in det_dict:
+            raise UserError(f'The "det_mode={det_mode}" you are trying to use '
+                            f'is not supported. Use one of {list(det_dict.keys())} '
+                            f'for the det_mode.')
 
         _tth_offset = np.deg2rad(getattr(self.detector_offests, det_dict[det_mode]).get())
 


### PR DESCRIPTION
This check will produce the following exception if the provided mode is wrong.
```py
UserError                                 Traceback (most recent call last)
<ipython-input-5-bf43fac12b6e> in <module>
      6
      7 if det_mode not in det_dict:
----> 8     raise UserError(f'The "det_mode={det_mode}" you are trying to use '
      9                     f'is not supported. Use one of: {list(det_dict.keys())} '
     10                     f'for the det_mode.')

UserError: The "det_mode=0" you are trying to use is not supported. Use one of: [1, 2, 3] for the det_mode.
```

It should rather be enforced by the enum-type for this input on the EPICS level.